### PR TITLE
Variation fix

### DIFF
--- a/Jantimizer/ExperimentSuite/experiments.json
+++ b/Jantimizer/ExperimentSuite/experiments.json
@@ -3,7 +3,7 @@
     {
       "ExperimentName": "Experiment One",
       "RunParallel": true,
-      "RunExperiment": true,
+      "RunExperiment": false,
       "PreRunData": [
         {
           "ConnectorName": "POSGRESQL",

--- a/Jantimizer/ExperimentSuite/experiments.json
+++ b/Jantimizer/ExperimentSuite/experiments.json
@@ -3,7 +3,7 @@
     {
       "ExperimentName": "Experiment One",
       "RunParallel": true,
-      "RunExperiment": false,
+      "RunExperiment": true,
       "PreRunData": [
         {
           "ConnectorName": "POSGRESQL",

--- a/Jantimizer/Histograms/Caches/CachedBucket.cs
+++ b/Jantimizer/Histograms/Caches/CachedBucket.cs
@@ -13,14 +13,14 @@ namespace Histograms.Caches
         public string ValueStart { get; }
         public string ValueEnd { get; }
         public long Count { get; }
-        public decimal Variance { get; }
-        public decimal StandardDeviation { get; }
-        public decimal Mean { get; }
+        public double Variance { get; }
+        public double StandardDeviation { get; }
+        public double Mean { get; }
         public string TypeName { get; }
         public string ValueType { get; }
 
         [JsonConstructorAttribute]
-        public CachedBucket(string valueStart, string valueEnd, long count, decimal variance, decimal mean, decimal standardDeviation, string typeName, string valueType)
+        public CachedBucket(string valueStart, string valueEnd, long count, double variance, double mean, double standardDeviation, string typeName, string valueType)
         {
             ValueStart = valueStart;
             ValueEnd = valueEnd;

--- a/Jantimizer/Histograms/Caches/CachedBucket.cs
+++ b/Jantimizer/Histograms/Caches/CachedBucket.cs
@@ -13,19 +13,21 @@ namespace Histograms.Caches
         public string ValueStart { get; }
         public string ValueEnd { get; }
         public long Count { get; }
-        public int Variance { get; }
-        public int Mean { get; }
+        public decimal Variance { get; }
+        public decimal StandardDeviation { get; }
+        public decimal Mean { get; }
         public string TypeName { get; }
         public string ValueType { get; }
 
         [JsonConstructorAttribute]
-        public CachedBucket(string valueStart, string valueEnd, long count, int variance, int mean, string typeName, string valueType)
+        public CachedBucket(string valueStart, string valueEnd, long count, decimal variance, decimal mean, decimal standardDeviation, string typeName, string valueType)
         {
             ValueStart = valueStart;
             ValueEnd = valueEnd;
             Count = count;
             Variance = variance;
             Mean = mean;
+            StandardDeviation = standardDeviation;
             TypeName = typeName;
             ValueType = valueType;
         }
@@ -46,6 +48,7 @@ namespace Histograms.Caches
             Count = bucket.Count;
             Variance = bucket.Variance;
             Mean = bucket.Mean;
+            StandardDeviation = bucket.StandardDeviation;
             ValueType = bucket.ValueStart.GetType().ToString();
             TypeName = nameof(HistogramBucketVariance);
         }

--- a/Jantimizer/Histograms/Models/Buckets/HistogramBucketVariance.cs
+++ b/Jantimizer/Histograms/Models/Buckets/HistogramBucketVariance.cs
@@ -2,18 +2,20 @@
 {
     public class HistogramBucketVariance : HistogramBucket, IHistogramBucketVariance
     {
-        public int Variance { get; internal set; }
-        public int Mean { get; internal set; }
+        public decimal Variance { get; internal set; }
+        public decimal Mean { get; internal set; }
+        public decimal StandardDeviation { get; internal set; }
 
-        public HistogramBucketVariance(IComparable valueStart, IComparable valueEnd, long count, int variance, int mean) : base(valueStart, valueEnd, count)
+        public HistogramBucketVariance(IComparable valueStart, IComparable valueEnd, long count, decimal variance, decimal mean, decimal standardDeviation) : base(valueStart, valueEnd, count)
         {
             Variance = variance;
             Mean = mean;
+            StandardDeviation = standardDeviation;
         }
 
         public override string? ToString()
         {
-            return $"Start: [{ValueStart}], End: [{ValueEnd}], Count: [{Count}], Variance: [{Variance}], Mean: [{Mean}]";
+            return $"Start: [{ValueStart}], End: [{ValueEnd}], Count: [{Count}], Variance: [{Variance}], Mean: [{Mean}], Standard Deviation [{StandardDeviation}]";
         }
     }
 }

--- a/Jantimizer/Histograms/Models/Buckets/HistogramBucketVariance.cs
+++ b/Jantimizer/Histograms/Models/Buckets/HistogramBucketVariance.cs
@@ -2,11 +2,11 @@
 {
     public class HistogramBucketVariance : HistogramBucket, IHistogramBucketVariance
     {
-        public decimal Variance { get; internal set; }
-        public decimal Mean { get; internal set; }
-        public decimal StandardDeviation { get; internal set; }
+        public double Variance { get; internal set; }
+        public double Mean { get; internal set; }
+        public double StandardDeviation { get; internal set; }
 
-        public HistogramBucketVariance(IComparable valueStart, IComparable valueEnd, long count, decimal variance, decimal mean, decimal standardDeviation) : base(valueStart, valueEnd, count)
+        public HistogramBucketVariance(IComparable valueStart, IComparable valueEnd, long count, double variance, double mean, double standardDeviation) : base(valueStart, valueEnd, count)
         {
             Variance = variance;
             Mean = mean;

--- a/Jantimizer/Histograms/Models/Buckets/IHistogramBucketVariance.cs
+++ b/Jantimizer/Histograms/Models/Buckets/IHistogramBucketVariance.cs
@@ -2,7 +2,8 @@
 {
     public interface IHistogramBucketVariance : IHistogramBucket
     {
-        public int Variance { get; }
-        public int Mean { get; }
+        public decimal Variance { get; }
+        public decimal StandardDeviation { get; }
+        public decimal Mean { get; }
     }
 }

--- a/Jantimizer/Histograms/Models/Buckets/IHistogramBucketVariance.cs
+++ b/Jantimizer/Histograms/Models/Buckets/IHistogramBucketVariance.cs
@@ -2,8 +2,8 @@
 {
     public interface IHistogramBucketVariance : IHistogramBucket
     {
-        public decimal Variance { get; }
-        public decimal StandardDeviation { get; }
-        public decimal Mean { get; }
+        public double Variance { get; }
+        public double StandardDeviation { get; }
+        public double Mean { get; }
     }
 }

--- a/Jantimizer/Histograms/Models/Histograms/HistogramEquiDepthVariance.cs
+++ b/Jantimizer/Histograms/Models/Histograms/HistogramEquiDepthVariance.cs
@@ -30,7 +30,7 @@ namespace Histograms.Models
                     if (valueStart == null || valueEnd == null)
                         throw new ArgumentNullException("Read bucket value was invalid!");
 
-                    Buckets.Add(new HistogramBucketVariance(valueStart, valueEnd, bucket.Count, bucket.Variance, bucket.Mean));
+                    Buckets.Add(new HistogramBucketVariance(valueStart, valueEnd, bucket.Count, bucket.Variance, bucket.Mean, bucket.StandardDeviation));
                 }
             }
         }
@@ -42,28 +42,28 @@ namespace Histograms.Models
                 IComparable startValue = sorted[bStart];
                 IComparable endValue = sorted[bStart];
                 int countValue = 1;
-                int mean = (int)endValue;
-                int variance = 0;
+                decimal mean = Convert.ToDecimal(endValue);
+                decimal variance = 0;
+                decimal standardDeviation = 0;
 
                 for (int bIter = bStart + 1; bIter < bStart + Depth && bIter < sorted.Count; bIter++)
                 {
                     countValue++;
-                    endValue = sorted[bIter];
-                    mean += (int)endValue;
+                    mean += Convert.ToDecimal(sorted[bIter]);
                 }
                 mean = mean / countValue;
                 for (int bIter = bStart; bIter < bStart + Depth && bIter < sorted.Count; bIter++)
                 {
-                    variance += (int)Math.Pow((int)sorted[bIter] - mean, 2);
+                    variance += (decimal)Math.Pow(Convert.ToDouble(sorted[bIter]) - (double)mean, 2);
                 }
                 if (countValue > 1 && variance != 0)
-                    variance = (int)Math.Sqrt(variance / countValue - 1);
+                    standardDeviation = (decimal)Math.Sqrt((double)variance / countValue - 1);
                 else
                     variance = 0;
                 if (variance < 0)
                     variance = 0;
 
-                Buckets.Add(new HistogramBucketVariance(startValue, endValue, countValue, variance, mean));
+                Buckets.Add(new HistogramBucketVariance(startValue, endValue, countValue, variance, mean, standardDeviation));
             }
         }
 
@@ -72,7 +72,7 @@ namespace Histograms.Models
             var retObj = new HistogramEquiDepthVariance(TableName, AttributeName, Depth);
             foreach (var bucket in Buckets)
                 if (bucket is IHistogramBucketVariance vari)
-                    retObj.Buckets.Add(new HistogramBucketVariance(vari.ValueStart, vari.ValueEnd, vari.Count, vari.Variance, vari.Mean));
+                    retObj.Buckets.Add(new HistogramBucketVariance(vari.ValueStart, vari.ValueEnd, vari.Count, vari.Variance, vari.Mean, vari.StandardDeviation));
             return retObj;
         }
     }

--- a/Jantimizer/Histograms/Models/Histograms/HistogramEquiDepthVariance.cs
+++ b/Jantimizer/Histograms/Models/Histograms/HistogramEquiDepthVariance.cs
@@ -58,7 +58,7 @@ namespace Histograms.Models
                     variance += Math.Pow(Convert.ToDouble(sorted[bIter]) - (double)mean, 2);
                 }
                 if (countValue > 1 && variance != 0)
-                    standardDeviation = Math.Sqrt((double)variance / countValue - 1);
+                    standardDeviation = Math.Sqrt((double)variance / countValue);
                 else
                     variance = 0;
                 if (variance < 0)

--- a/Jantimizer/Histograms/Models/Histograms/HistogramEquiDepthVariance.cs
+++ b/Jantimizer/Histograms/Models/Histograms/HistogramEquiDepthVariance.cs
@@ -42,22 +42,23 @@ namespace Histograms.Models
                 IComparable startValue = sorted[bStart];
                 IComparable endValue = sorted[bStart];
                 int countValue = 1;
-                decimal mean = Convert.ToDecimal(endValue);
-                decimal variance = 0;
-                decimal standardDeviation = 0;
+                double mean = Convert.ToDouble(endValue);
+                double variance = 0;
+                double standardDeviation = 0;
 
                 for (int bIter = bStart + 1; bIter < bStart + Depth && bIter < sorted.Count; bIter++)
                 {
                     countValue++;
-                    mean += Convert.ToDecimal(sorted[bIter]);
+                    endValue = sorted[bIter];
+                    mean += Convert.ToDouble(endValue);
                 }
                 mean = mean / countValue;
                 for (int bIter = bStart; bIter < bStart + Depth && bIter < sorted.Count; bIter++)
                 {
-                    variance += (decimal)Math.Pow(Convert.ToDouble(sorted[bIter]) - (double)mean, 2);
+                    variance += Math.Pow(Convert.ToDouble(sorted[bIter]) - (double)mean, 2);
                 }
                 if (countValue > 1 && variance != 0)
-                    standardDeviation = (decimal)Math.Sqrt((double)variance / countValue - 1);
+                    standardDeviation = Math.Sqrt((double)variance / countValue - 1);
                 else
                     variance = 0;
                 if (variance < 0)

--- a/Jantimizer/HistogramsTests/Stubs/BadBucketVariance.cs
+++ b/Jantimizer/HistogramsTests/Stubs/BadBucketVariance.cs
@@ -15,8 +15,10 @@ namespace HistogramsTests.Stubs
 
         public long Count => throw new NotImplementedException();
 
-        public int Variance => throw new NotImplementedException();
+        public decimal Variance => throw new NotImplementedException();
 
-        public int Mean => throw new NotImplementedException();
+        public decimal Mean => throw new NotImplementedException();
+
+        public decimal StandardDeviation => throw new NotImplementedException();
     }
 }

--- a/Jantimizer/HistogramsTests/Stubs/BadBucketVariance.cs
+++ b/Jantimizer/HistogramsTests/Stubs/BadBucketVariance.cs
@@ -15,10 +15,10 @@ namespace HistogramsTests.Stubs
 
         public long Count => throw new NotImplementedException();
 
-        public decimal Variance => throw new NotImplementedException();
+        public double Variance => throw new NotImplementedException();
 
-        public decimal Mean => throw new NotImplementedException();
+        public double Mean => throw new NotImplementedException();
 
-        public decimal StandardDeviation => throw new NotImplementedException();
+        public double StandardDeviation => throw new NotImplementedException();
     }
 }

--- a/Jantimizer/HistogramsTests/Unit Tests/Caches/CachedBucketTests.cs
+++ b/Jantimizer/HistogramsTests/Unit Tests/Caches/CachedBucketTests.cs
@@ -35,13 +35,13 @@ namespace HistogramsTests.Unit_Tests.Caches
         }
 
         [TestMethod]
-        [DataRow(0, 1, 10, 1, 1)]
-        [DataRow(10, 999991, 1, 500, 204)]
-        [DataRow(0, 20, 199998, 888, 1)]
-        public void Constructor_CanSetWith_HistogramBucketVariance(int start, int end, long count, int variance, int mean)
+        [DataRow(0, 1, 10, 1.0, 1.0, 5.2)]
+        [DataRow(10, 999991, 1, 500, 204, 9284.2)]
+        [DataRow(0, 20, 199998, 888, 1, 0.99996)]
+        public void Constructor_CanSetWith_HistogramBucketVariance(int start, int end, long count, double variance, double mean, double sd)
         {
             // ARRANGE
-            HistogramBucketVariance histogramBucket = new HistogramBucketVariance(start, end, count, variance, mean);
+            HistogramBucketVariance histogramBucket = new HistogramBucketVariance(start, end, count, variance, mean, sd);
 
             // ACT
             CachedBucket bucket = new CachedBucket(histogramBucket);
@@ -52,6 +52,7 @@ namespace HistogramsTests.Unit_Tests.Caches
             Assert.AreEqual(count, bucket.Count);
             Assert.AreEqual(variance, bucket.Variance);
             Assert.AreEqual(mean, bucket.Mean);
+            Assert.AreEqual(sd, bucket.StandardDeviation);
             Assert.AreEqual(nameof(HistogramBucketVariance), bucket.TypeName);
         }
 

--- a/Jantimizer/HistogramsTests/Unit Tests/Caches/CachedHistogramTests.cs
+++ b/Jantimizer/HistogramsTests/Unit Tests/Caches/CachedHistogramTests.cs
@@ -46,9 +46,9 @@ namespace HistogramsTests.Unit_Tests.Caches
             // ARRANGE
             HistogramEquiDepthVariance histogram = new HistogramEquiDepthVariance(tableName, attributeName, depth);
             List<IHistogramBucket> buckets = new List<IHistogramBucket>();
-            buckets.Add(new HistogramBucketVariance(0, 1, 1, 0, 0));
-            buckets.Add(new HistogramBucketVariance(0, 1, 1, 0, 0));
-            buckets.Add(new HistogramBucketVariance(0, 1, 1, 0, 0));
+            buckets.Add(new HistogramBucketVariance(0, 1, 1, 0, 0, 0));
+            buckets.Add(new HistogramBucketVariance(0, 1, 1, 0, 0, 0));
+            buckets.Add(new HistogramBucketVariance(0, 1, 1, 0, 0, 0));
             histogram.Buckets.AddRange(buckets);
 
             // ACT

--- a/Jantimizer/HistogramsTests/Unit Tests/Models/Buckets/HistogramBucketVarianceTests.cs
+++ b/Jantimizer/HistogramsTests/Unit Tests/Models/Buckets/HistogramBucketVarianceTests.cs
@@ -14,15 +14,15 @@ namespace HistogramsTests.Unit_Tests.Models.Buckets
         #region Constructor
 
         [TestMethod]
-        [DataRow(1, 5, 10, 5, 10)]
-        [DataRow(111, 112, 1000, 10, 5)]
-        [DataRow(1, 50000, 10, 1, 1)]
-        [DataRow(1, 5, 110000, 1, 1000)]
-        public void Constructor_SetsProperties(int start, int stop, int count, int variance, int mean)
+        [DataRow(1, 5, 10, 5, 10, 5.2)]
+        [DataRow(111, 112, 1000, 10, 5, 34745.21564)]
+        [DataRow(1, 50000, 10, 1, 1, 0.000054)]
+        [DataRow(1, 5, 110000, 1, 1000, 1)]
+        public void Constructor_SetsProperties(int start, int stop, int count, double variance, double mean, double sd)
         {
             // ARRANGE
             // ACT
-            IHistogramBucketVariance bucket = new HistogramBucketVariance(start, stop, count, variance, mean);
+            IHistogramBucketVariance bucket = new HistogramBucketVariance(start, stop, count, variance, mean, sd);
 
             // ASSERT
             Assert.AreEqual(start, bucket.ValueStart);
@@ -30,6 +30,7 @@ namespace HistogramsTests.Unit_Tests.Models.Buckets
             Assert.AreEqual(count, bucket.Count);
             Assert.AreEqual(variance, bucket.Variance);
             Assert.AreEqual(mean, bucket.Mean);
+            Assert.AreEqual(sd, bucket.StandardDeviation);
         }
 
         #endregion
@@ -45,7 +46,7 @@ namespace HistogramsTests.Unit_Tests.Models.Buckets
         {
             // ARRANGE
             // ACT
-            new HistogramBucketVariance(start, stop, 10, 0, 0);
+            new HistogramBucketVariance(start, stop, 10, 0, 0, 0);
         }
 
         [TestMethod]
@@ -57,7 +58,7 @@ namespace HistogramsTests.Unit_Tests.Models.Buckets
         {
             // ARRANGE
             // ACT
-            new HistogramBucketVariance(1, 2, count, 0, 0);
+            new HistogramBucketVariance(1, 2, count, 0, 0, 0);
         }
 
         #endregion

--- a/Jantimizer/HistogramsTests/Unit Tests/Models/Histograms/HistogramEquiDepthVarianceTests.cs
+++ b/Jantimizer/HistogramsTests/Unit Tests/Models/Histograms/HistogramEquiDepthVarianceTests.cs
@@ -68,11 +68,11 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         }
 
         [TestMethod]
-        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14)]
+        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14.106735979665885)]
         [DataRow(new int[] { 1, 2, 3, 4, 5 }, 1)]
-        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48)]
-        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998)]
-        public void Can_GenerateHistogram_Table_Variance(int[] rows, int expVariance)
+        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48.979587585033826)]
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998.800041670833)]
+        public void Can_GenerateHistogram_Table_StandardDeviation(int[] rows, double expDeviation)
         {
             // ARRANGE
             IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", 5);
@@ -85,7 +85,7 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
 
             // ASSERT
             if (histogram.Buckets[0] is IHistogramBucketVariance var)
-                Assert.AreEqual(expVariance, var.Variance);
+                Assert.AreEqual(expDeviation, var.StandardDeviation);
             else
                 Assert.Fail();
         }
@@ -94,8 +94,8 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         [DataRow(new int[] { 0, 10, 20, 30, 40 }, 20)]
         [DataRow(new int[] { 1, 2, 3, 4, 5 }, 3)]
         [DataRow(new int[] { 100, 0, 0, 0, 100 }, 40)]
-        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 6002)]
-        public void Can_GenerateHistogram_Table_Mean(int[] rows, int expMean)
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 6002.4)]
+        public void Can_GenerateHistogram_Table_Mean(int[] rows, double expMean)
         {
             // ARRANGE
             IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", 5);
@@ -109,6 +109,29 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
             // ASSERT
             if (histogram.Buckets[0] is IHistogramBucketVariance var)
                 Assert.AreEqual(expMean, var.Mean);
+            else
+                Assert.Fail();
+        }
+
+        [TestMethod]
+        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 1000)]
+        [DataRow(new int[] { 1, 2, 3, 4, 5 }, 10)]
+        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 12000)]
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 719856017.1999998)]
+        public void Can_GenerateHistogram_Table_Variance(int[] rows, double expVariance)
+        {
+            // ARRANGE
+            IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", 5);
+            DataTable table = DataTableHelper.GetDatatable("b", typeof(int));
+            foreach (int row in rows)
+                DataTableHelper.AddRow(table, new int[] { row });
+
+            // ACT
+            histogram.GenerateHistogram(table, "b");
+
+            // ASSERT
+            if (histogram.Buckets[0] is IHistogramBucketVariance var)
+                Assert.AreEqual(expVariance, var.Variance);
             else
                 Assert.Fail();
         }
@@ -135,11 +158,11 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         }
 
         [TestMethod]
-        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14)]
+        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14.106735979665885)]
         [DataRow(new int[] { 1, 2, 3, 4, 5 }, 1)]
-        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48)]
-        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998)]
-        public void Can_GenerateHistogram_List_Variance(int[] rows, int expVariance)
+        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48.979587585033826)]
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998.800041670833)]
+        public void Can_GenerateHistogram_List_StandardDeviation(int[] rows, double expDeviation)
         {
             // ARRANGE
             IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", 5);
@@ -149,7 +172,7 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
 
             // ASSERT
             if (histogram.Buckets[0] is IHistogramBucketVariance var)
-                Assert.AreEqual(expVariance, var.Variance);
+                Assert.AreEqual(expDeviation, var.StandardDeviation);
             else
                 Assert.Fail();
         }
@@ -158,8 +181,8 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         [DataRow(new int[] { 0, 10, 20, 30, 40 }, 20)]
         [DataRow(new int[] { 1, 2, 3, 4, 5 }, 3)]
         [DataRow(new int[] { 100, 0, 0, 0, 100 }, 40)]
-        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 6002)]
-        public void Can_GenerateHistogram_List_Mean(int[] rows, int expMean)
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 6002.4)]
+        public void Can_GenerateHistogram_List_Mean(int[] rows, double expMean)
         {
             // ARRANGE
             IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", 5);
@@ -170,6 +193,26 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
             // ASSERT
             if (histogram.Buckets[0] is IHistogramBucketVariance var)
                 Assert.AreEqual(expMean, var.Mean);
+            else
+                Assert.Fail();
+        }
+
+        [TestMethod]
+        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 1000)]
+        [DataRow(new int[] { 1, 2, 3, 4, 5 }, 10)]
+        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 12000)]
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 719856017.1999998)]
+        public void Can_GenerateHistogram_List_Variance(int[] rows, double expVariance)
+        {
+            // ARRANGE
+            IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", 5);
+
+            // ACT
+            histogram.GenerateHistogram(rows.Cast<IComparable>().ToList());
+
+            // ASSERT
+            if (histogram.Buckets[0] is IHistogramBucketVariance var)
+                Assert.AreEqual(expVariance, var.Variance);
             else
                 Assert.Fail();
         }
@@ -201,12 +244,12 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         }
 
         [TestMethod]
-        [DataRow(new int[] { 1 }, new long[] { 20 }, 10, new int[] { 0, 0 })]
-        [DataRow(new int[] { 1 }, new long[] { 20 }, 20, new int[] { 0 })]
-        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new int[] { 0, 93, 0, 0, 0 })]
-        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new int[] { 0, 0, 0, 1, 0 })]
-        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new int[] { 3, 2, 0, 0, 14 })]
-        public void Can_GenerateHistogramFromSorted_Variance(int[] value, long[] count, int bucketSize, int[] expVariances)
+        [DataRow(new int[] { 1 }, new long[] { 20 }, 10, new double[] { 0, 0 })]
+        [DataRow(new int[] { 1 }, new long[] { 20 }, 20, new double[] { 0 })]
+        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new double[] { 0, 132003.3333333333, 0, 0, 0 })]
+        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new double[] { 0, 0, 0, 10.666666666666668, 0 })]
+        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new double[] { 303.75, 183.75, 0, 0, 3387.0588235294135 })]
+        public void Can_GenerateHistogramFromSorted_Variance(int[] value, long[] count, int bucketSize, double[] expVariances)
         {
             // ARRANGE
             IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", bucketSize);
@@ -229,12 +272,12 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         }
 
         [TestMethod]
-        [DataRow(new int[] { 1 }, new long[] { 20 }, 10, new int[] { 1, 1 })]
-        [DataRow(new int[] { 1 }, new long[] { 20 }, 20, new int[] { 1 })]
-        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new int[] { 1, 133, 200, 200, 200 })]
-        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new int[] { 1, 1, 1, 3, 5 })]
-        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new int[] { 7, 15, 17, 17, 28 })]
-        public void Can_GenerateHistogramFromSorted_Mean(int[] value, long[] count, int bucketSize, int[] expVariances)
+        [DataRow(new int[] { 1 }, new long[] { 20 }, 10, new double[] { 0, 0 })]
+        [DataRow(new int[] { 1 }, new long[] { 20 }, 20, new double[] { 0 })]
+        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new double[] { 0, 93.8041695353795, 0, 0, 0 })]
+        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new double[] { 0, 0, 0, 1.5986105077709065, 0 })]
+        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new double[] { 3.766629793329841, 2.8613807855648994, 0, 0, 14.079728489046214 })]
+        public void Can_GenerateHistogramFromSorted_StandardDeviation(int[] value, long[] count, int bucketSize, double[] expDeviations)
         {
             // ARRANGE
             IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", bucketSize);
@@ -250,7 +293,35 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
             for (int i = 0; i < histogram.Buckets.Count; i++)
             {
                 if (histogram.Buckets[i] is IHistogramBucketVariance var)
-                    Assert.AreEqual(expVariances[i], var.Mean);
+                    Assert.AreEqual(expDeviations[i], var.StandardDeviation);
+                else
+                    Assert.Fail();
+            }
+        }
+
+        [TestMethod]
+        [DataRow(new int[] { 1 }, new long[] { 20 }, 10, new double[] { 1, 1 })]
+        [DataRow(new int[] { 1 }, new long[] { 20 }, 20, new double[] { 1 })]
+        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new double[] { 1, 133.66666666666666, 200, 200, 200 })]
+        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new double[] { 1, 1, 1, 3.6666666666666665, 5 })]
+        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new double[] { 7.75, 15.25, 17, 17, 28.764705882352942 })]
+        public void Can_GenerateHistogramFromSorted_Mean(int[] value, long[] count, int bucketSize, double[] expMeans)
+        {
+            // ARRANGE
+            IDepthHistogram histogram = new HistogramEquiDepthVariance("A", "b", bucketSize);
+            List<ValueCount> values = new List<ValueCount>();
+            for (int i = 0; i < value.Length; i++)
+                values.Add(new ValueCount(value[i], count[i]));
+
+            // ACT
+            histogram.GenerateHistogramFromSortedGroups(values);
+
+            // ASSERT
+            Assert.IsTrue(histogram.Buckets.Count > 0);
+            for (int i = 0; i < histogram.Buckets.Count; i++)
+            {
+                if (histogram.Buckets[i] is IHistogramBucketVariance var)
+                    Assert.AreEqual(expMeans[i], var.Mean);
                 else
                     Assert.Fail();
             }

--- a/Jantimizer/HistogramsTests/Unit Tests/Models/Histograms/HistogramEquiDepthVarianceTests.cs
+++ b/Jantimizer/HistogramsTests/Unit Tests/Models/Histograms/HistogramEquiDepthVarianceTests.cs
@@ -68,10 +68,10 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         }
 
         [TestMethod]
-        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14.106735979665885)]
-        [DataRow(new int[] { 1, 2, 3, 4, 5 }, 1)]
-        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48.979587585033826)]
-        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998.800041670833)]
+        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14.142135623730951)]
+        [DataRow(new int[] { 1, 2, 3, 4, 5 }, 1.4142135623730951)]
+        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48.98979485566356)]
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998.800083341666)]
         public void Can_GenerateHistogram_Table_StandardDeviation(int[] rows, double expDeviation)
         {
             // ARRANGE
@@ -158,10 +158,10 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         }
 
         [TestMethod]
-        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14.106735979665885)]
-        [DataRow(new int[] { 1, 2, 3, 4, 5 }, 1)]
-        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48.979587585033826)]
-        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998.800041670833)]
+        [DataRow(new int[] { 0, 10, 20, 30, 40 }, 14.142135623730951)]
+        [DataRow(new int[] { 1, 2, 3, 4, 5 }, 1.4142135623730951)]
+        [DataRow(new int[] { 100, 0, 0, 0, 100 }, 48.98979485566356)]
+        [DataRow(new int[] { 1, 2, 30000, 4, 5 }, 11998.800083341666)]
         public void Can_GenerateHistogram_List_StandardDeviation(int[] rows, double expDeviation)
         {
             // ARRANGE
@@ -274,9 +274,9 @@ namespace HistogramsTests.Unit_Tests.Models.Histograms
         [TestMethod]
         [DataRow(new int[] { 1 }, new long[] { 20 }, 10, new double[] { 0, 0 })]
         [DataRow(new int[] { 1 }, new long[] { 20 }, 20, new double[] { 0 })]
-        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new double[] { 0, 93.8041695353795, 0, 0, 0 })]
-        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new double[] { 0, 0, 0, 1.5986105077709065, 0 })]
-        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new double[] { 3.766629793329841, 2.8613807855648994, 0, 0, 14.079728489046214 })]
+        [DataRow(new int[] { 1, 200 }, new long[] { 20, 50 }, 15, new double[] { 0, 93.8094996374153, 0, 0, 0 })]
+        [DataRow(new int[] { 1, 5 }, new long[] { 10, 5 }, 3, new double[] { 0, 0, 0, 1.8856180831641267, 0 })]
+        [DataRow(new int[] { 1, 10, 17, 2, 40 }, new long[] { 5, 20, 60, 2, 10 }, 20, new double[] { 3.897114317029974, 3.031088913245535, 0, 0, 14.115195865635716 })]
         public void Can_GenerateHistogramFromSorted_StandardDeviation(int[] value, long[] count, int bucketSize, double[] expDeviations)
         {
             // ARRANGE

--- a/Jantimizer/QueryOptimiser/Cost/Nodes/JoinCostEquiDepthVariance.cs
+++ b/Jantimizer/QueryOptimiser/Cost/Nodes/JoinCostEquiDepthVariance.cs
@@ -117,7 +117,7 @@ namespace QueryOptimiser.Cost.Nodes.EquiDepthVariance
 
         private long GetVariatedCount(HistogramBucketVariance bucket, HistogramBucketVariance comparisonBucket)
         {
-            double certainty = (double)Math.Abs((double)bucket.Variance / comparisonBucket.Variance);
+            double certainty = (double)Math.Abs(bucket.Variance / comparisonBucket.Variance);
             if (certainty > 1)
                 certainty = 1 / certainty;
             long estimate = (long)(bucket.Count * certainty);


### PR DESCRIPTION
Fixed so that variation is actually variation and not standard deviation.
Also included standard deviation (in case it is being used in other branches), and set the `Variance`, `Mean` and `StandardDeviation` properties to be double instead, so we can actually use decimal numbers.
closes #161 